### PR TITLE
Fixes / Workaround

### DIFF
--- a/MyNetFxApp2/App.config
+++ b/MyNetFxApp2/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    </startup>
+</configuration>

--- a/MyNetFxApp2/MyNetFxApp.csproj
+++ b/MyNetFxApp2/MyNetFxApp.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+   <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyLibrary\MyLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyNetFxApp2/Program.cs
+++ b/MyNetFxApp2/Program.cs
@@ -1,0 +1,18 @@
+﻿using MyLibrary;
+using System;
+
+namespace MyNetFxApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Before calling constructor");
+            Class1 class1 = new Class1();
+            Console.WriteLine("Constructed");
+            class1.LoadNethereum();
+            Console.WriteLine("Called LoadNethereum");
+            Console.ReadKey();
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -25,3 +25,39 @@ Unhandled Exception: System.IO.FileLoadException: Could not load file or assembl
    at MyLibrary.Class1.LoadNethereum()
    at MyNetFxApp.Program.Main(String[] args) in D:\Demos\NugetVersionRangeDemo\MyLibrary\MyNetFxApp\Program.cs:line 13
 ```
+
+
+# Working steps using the new Project file format 
+
+1. Create new folder at root `MyNetFxApp2`
+
+2. Create new project file as follows:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+   <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyLibrary\MyLibrary.csproj" />
+  </ItemGroup>
+
+</Project>
+
+```
+2. Copy all contents from the original  and remove the Assembly info from Properties
+3. Run
+
+```
+dotnet restore
+dotnet build
+dotnet publish
+
+```
+
+4. execute at Debug\net472\publish\MyNetFxApp.exe
+
+You will see now all the dll files are restored and copied correctly when publishing.


### PR DESCRIPTION
Using the new project format solves the problem. This prevents having to copy and paste dlls from other projects and does the "restoring", "building" and "publishing" properly. 